### PR TITLE
Fix weird chruby issue on new terminal windows

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -496,7 +496,8 @@ prompt_ruby() {
   if command -v rvm-prompt > /dev/null 2>&1; then
     prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX" $(rvm-prompt i v g)"
   elif command -v chruby > /dev/null 2>&1; then
-    prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX"  $(chruby | sed -n -e 's/ \* //p')"
+    chruby_version=`(chruby | grep -oE '\* .*' || ruby -e 'puts "* ruby-#{RUBY_VERSION}"') | cut -c 3-`
+    prompt_segment $BULLETTRAIN_RUBY_BG $BULLETTRAIN_RUBY_FG $BULLETTRAIN_RUBY_PREFIX"  $chruby_version"
   elif command -v rbenv > /dev/null 2>&1; then
     current_gemset() {
       echo "$(rbenv gemset active 2&>/dev/null | sed -e 's/ global$//')"


### PR DESCRIPTION
With chruby auto, sometimes it doesn't respond to the ruby version. This will use the system ruby so you aren't set with just a plain diamond symbol.
