### PR TITLE
Hide git prompt completely if git config flag "oh-my-zsh.hide-status" is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |`BULLETTRAIN_GIT_BEHIND`|`" ⬇"`|Icon for behind state from remote
 |`BULLETTRAIN_GIT_DIVERGED`|`" ⬍"`|Icon for diverged state from remote
 
+The git prompt can be disabled for a specific repository by setting a git config flag: `get config oh-my-zsh.hide-status 1`. This is useful to avoid performance issues for particularly huge repositories.
+
 ### Mercurial/HG
 
 |Variable|Default|Meaning

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -357,6 +357,10 @@ prompt_custom() {
 
 # Git
 prompt_git() {
+  if [[ "$(command git config --get oh-my-zsh.hide-status 2>/dev/null)" == "1" ]]; then
+    return
+  fi
+
   local ref dirty mode repo_path git_prompt
   repo_path=$(git rev-parse --git-dir 2>/dev/null)
 


### PR DESCRIPTION
Currently, when handling large git repositories on weak machines, generating the prompt can be really slow. For most oh-my-zsh themes, a good workaround is to manually set the "oh-my-zsh.hide-status" git config flag, which causes the `git_prompt_info` function to do nothing.

However, bullet-train does some extra work besides calling `git_prompt_info`. Therefore, setting this flag causes the git part of the prompt to be only partially hidden, and there is still an annoying delay. This should be fixed.

I have tested this fix successfully on my machines, and the check is basically the same as in Oh My Zsh (see https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh#L4).