### PR TITLE
Remove extra space in go prompt

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -122,7 +122,7 @@ if [ ! -n "${BULLETTRAIN_GO_FG+1}" ]; then
   BULLETTRAIN_GO_FG=white
 fi
 if [ ! -n "${BULLETTRAIN_GO_PREFIX+1}" ]; then
-  BULLETTRAIN_GO_PREFIX="go "
+  BULLETTRAIN_GO_PREFIX="go"
 fi
 
 # DIR


### PR DESCRIPTION
```
go 1.7
```
instead of
```
go  1.7
```