### PR TITLE
Bringing back the final prompt chars space

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -524,7 +524,7 @@ prompt_status() {
 
 # Prompt Character
 prompt_chars() {
-  local bt_prompt_chars="${BULLETTRAIN_PROMPT_CHAR}"
+  local bt_prompt_chars="${BULLETTRAIN_PROMPT_CHAR} "
 
   if [[ $BULLETTRAIN_PROMPT_ROOT == true ]]; then
     bt_prompt_chars="%(!.%F{red}# .%F{green}${bt_prompt_chars}%f)"


### PR DESCRIPTION
In the PR #162, the final space after the prompt chars was removed. This PR is bringing it back.