### PR TITLE
Add space after the prompt (\$)

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -534,7 +534,7 @@ prompt_chars() {
     bt_prompt_chars="${bt_prompt_chars}"
   fi
 
-  echo -n $bt_prompt_chars
+  echo -n "$bt_prompt_chars "
 }
 
 # Prompt Line Separator


### PR DESCRIPTION
Since the latest version after the $ / # a space is missing