### PR TITLE
Fix prompt_go matching pattern

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -499,7 +499,7 @@ prompt_perl() {
 # Go
 prompt_go() {
   setopt extended_glob
-  if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
+  if [[ ($(echo *.go(#qN)) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
       prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
     fi


### PR DESCRIPTION
`test -f *.go(#qN)` result is false in a directory with multiple go source files, because `-f` only take one argument. We need to combine the glob into a single string.