### PR TITLE
improved support of virtualenv name

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |--------|-------|-------|
 |`BULLETTRAIN_VIRTUALENV_BG`|`yellow`|Background color
 |`BULLETTRAIN_VIRTUALENV_FG`|`white`|Foreground color
+|`BULLETTRAIN_VIRTUALENV_NAME`|` %m`|Text to show after the prefix (use %m for virtualenv name)
 |`BULLETTRAIN_VIRTUALENV_PREFIX`|`🐍`|Prefix of the segment
 
 ### node.js nvm

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -90,6 +90,9 @@ fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_FG+1}" ]; then
   BULLETTRAIN_VIRTUALENV_FG=white
 fi
+if [ ! -n "${BULLETTRAIN_VIRTUALENV_NAME+1}" ]; then
+  BULLETTRAIN_VIRTUALENV_NAME=" %m"
+fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_PREFIX+1}" ]; then
   BULLETTRAIN_VIRTUALENV_PREFIX=🐍
 fi
@@ -509,10 +512,14 @@ prompt_go() {
 # Virtualenv: current working virtualenv
 prompt_virtualenv() {
   local virtualenv_path="$VIRTUAL_ENV"
-  if [[ -n $virtualenv_path && -n $VIRTUAL_ENV_DISABLE_PROMPT ]]; then
-    prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(basename $virtualenv_path)"
-  elif which pyenv &> /dev/null; then
-    prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed 's/.$//')"
+  if [[ -n $VIRTUAL_ENV_DISABLE_PROMPT && -n $virtualenv_path ]]; then
+    if which pyenv &> /dev/null; then
+      local virtualenv_name="$(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed 's/.$//')"
+    else
+      local virtualenv_name="$(basename $virtualenv_path)"
+    fi
+    local virtualenv_name=${BULLETTRAIN_VIRTUALENV_NAME:gs/%m/"${virtualenv_name}"}   # expand the %m
+    prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX"$virtualenv_name"
   fi
 }
 


### PR DESCRIPTION
Allow things like 'hello {venv name} !' to be shown after the prefix,
and fix (something that, to me, looks like) a problem explained in #220 .
Doc also is updated.

I need this for personal use, but i don't know zsh well ; i would love to get feedbacks.