### PR TITLE
Added python version in prompt for current active virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
-|`BULLETTRAIN_GO_BG`|`green`|Background color
+|`BULLETTRAIN_GO_BG`|`cyan`|Background color
 |`BULLETTRAIN_GO_FG`|`white`|Foreground color
 |`BULLETTRAIN_GO_PREFIX`|`go`|Prefix of the segment
 
@@ -294,7 +294,7 @@ of the project:
   3	Michael Robinson
   3	Michael Cornell
   3	Iulian Onofrei
-  2 Dhia Abbassi
+  3	Dhia Abbassi
   2	itsZero (Chien-An Cho)
   2	Daniel Loader
   2	Charlie Smith

--- a/README.md
+++ b/README.md
@@ -151,9 +151,18 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 
 |Variable|Default|Meaning
 |--------|-------|-------|
+|`BULLETTRAIN_VIRTUALENV_PYTHON_VERSION`|`false`|Add current python version to prompt if `true`.
 |`BULLETTRAIN_VIRTUALENV_BG`|`yellow`|Background color
 |`BULLETTRAIN_VIRTUALENV_FG`|`white`|Foreground color
 |`BULLETTRAIN_VIRTUALENV_PREFIX`|`🐍`|Prefix of the segment
+
+### Python version (virtualenv)
+
+|Variable|Default|Meaning
+|--------|-------|-------|
+|`BULLETTRAIN_PYTHON_BG`|`cyan`|Background color
+|`BULLETTRAIN_PYTHON_FG`|`white`|Foreground color
+|`BULLETTRAIN_GO_PREFIX`|`Python`|Prefix of the segment
 
 ### node.js nvm
 
@@ -285,6 +294,7 @@ of the project:
   3	Michael Robinson
   3	Michael Cornell
   3	Iulian Onofrei
+  2 Dhia Abbassi
   2	itsZero (Chien-An Cho)
   2	Daniel Loader
   2	Charlie Smith

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -26,6 +26,7 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     perl
     ruby
     virtualenv
+    python
     nvm
     aws
     go
@@ -84,6 +85,9 @@ if [ ! -n "${BULLETTRAIN_CUSTOM_FG+1}" ]; then
 fi
 
 # VIRTUALENV
+if [ ! -n "${BULLETTRAIN_VIRTUALENV_PYTHON_VERSION+1}" ]; then
+  BULLETTRAIN_VIRTUALENV_PYTHON_VERSION=false
+fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_BG+1}" ]; then
   BULLETTRAIN_VIRTUALENV_BG=yellow
 fi
@@ -92,6 +96,17 @@ if [ ! -n "${BULLETTRAIN_VIRTUALENV_FG+1}" ]; then
 fi
 if [ ! -n "${BULLETTRAIN_VIRTUALENV_PREFIX+1}" ]; then
   BULLETTRAIN_VIRTUALENV_PREFIX=🐍
+fi
+
+# PYTHON
+if [ ! -n "${BULLETTRAIN_PYTHON_BG+1}" ]; then
+  BULLETTRAIN_PYTHON_BG=cyan
+fi
+if [ ! -n "${BULLETTRAIN_GO_FG+1}" ]; then
+  BULLETTRAIN_PYTHON_FG=white
+fi
+if [ ! -n "${BULLETTRAIN_GO_PREFIX+1}" ]; then
+  BULLETTRAIN_PYTHON_PREFIX="Python"
 fi
 
 # NVM
@@ -513,6 +528,15 @@ prompt_virtualenv() {
     prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(basename $virtualenv_path)"
   elif which pyenv &> /dev/null; then
     prompt_segment $BULLETTRAIN_VIRTUALENV_BG $BULLETTRAIN_VIRTUALENV_FG $BULLETTRAIN_VIRTUALENV_PREFIX" $(pyenv version | sed -e 's/ (set.*$//' | tr '\n' ' ' | sed 's/.$//')"
+  fi
+}
+
+# Python
+prompt_python() {
+  local python_version
+  if [[ -n $VIRTUAL_ENV && "$BULLETTRAIN_VIRTUALENV_PYTHON_VERSION" = true ]]; then
+    python_version=$(python -c "import sys; print('{0[0]}.{0[1]}'.format(sys.version_info))")
+    prompt_segment $BULLETTRAIN_PYTHON_BG $BULLETTRAIN_PYTHON_FG $BULLETTRAIN_PYTHON_PREFIX" $python_version"
   fi
 }
 


### PR DESCRIPTION
Now if you set the flag `BULLETTRAIN_VIRTUALENV_PYTHON_VERSION=true`, current python version will be added to the prompt segment. Colors and prefix can also be customized. 🐍

![screenshot from 2017-06-26 12-14-00](https://user-images.githubusercontent.com/2914703/27535071-857eba9e-5a69-11e7-984b-f3c970e963b0.png)
