### PR TITLE
Feature/issue 144

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |Variable|Default|Meaning
 |--------|-------|-------|
 |`BULLETTRAIN_PROMPT_CHAR`|`\$`|Character to be show before any command
+|`BULLETTRAIN_PROMPT_CHAR_FG`|`green`|Colour of the shell prompt
 |`BULLETTRAIN_PROMPT_ROOT`|`true`|Highlight if running as root
+|`BULLETTRAIN_PROMPT_ROOT_FG`|`red`|Colour of the shell prompt in root mode
 |`BULLETTRAIN_PROMPT_SEPARATE_LINE`|`true`|Make the prompt span across two lines
 |`BULLETTRAIN_PROMPT_ADD_NEWLINE`|`true`|Adds a newline character before each prompt line
 

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -40,8 +40,14 @@ fi
 if [ ! -n "${BULLETTRAIN_PROMPT_CHAR+1}" ]; then
   BULLETTRAIN_PROMPT_CHAR="\$"
 fi
+if [ ! -n "${BULLETTRAIN_PROMPT_CHAR_FG+1}" ]; then
+  BULLETTRAIN_PROMPT_CHAR_FG=green
+fi
 if [ ! -n "${BULLETTRAIN_PROMPT_ROOT+1}" ]; then
   BULLETTRAIN_PROMPT_ROOT=true
+fi
+if [ ! -n "${BULLETTRAIN_PROMPT_ROOT_FG+1}" ]; then
+  BULLETTRAIN_PROMPT_ROOT_FG=red
 fi
 if [ ! -n "${BULLETTRAIN_PROMPT_SEPARATE_LINE+1}" ]; then
   BULLETTRAIN_PROMPT_SEPARATE_LINE=true
@@ -571,7 +577,7 @@ prompt_chars() {
   local bt_prompt_chars="${BULLETTRAIN_PROMPT_CHAR}"
 
   if [[ $BULLETTRAIN_PROMPT_ROOT == true ]]; then
-    bt_prompt_chars="%(!.%F{red}#%f .%F{green}${bt_prompt_chars}%f)"
+    bt_prompt_chars="%(!.%F{$BULLETTRAIN_PROMPT_ROOT_FG}#%f .%F{$BULLETTRAIN_PROMPT_CHAR_FG}${bt_prompt_chars}%f)"
   fi
 
   if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false ]]; then

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -571,7 +571,7 @@ prompt_chars() {
   local bt_prompt_chars="${BULLETTRAIN_PROMPT_CHAR}"
 
   if [[ $BULLETTRAIN_PROMPT_ROOT == true ]]; then
-    bt_prompt_chars="%(!.%F{red}# .%F{green}${bt_prompt_chars}%f)"
+    bt_prompt_chars="%(!.%F{red}#%f .%F{green}${bt_prompt_chars}%f)"
   fi
 
   if [[ $BULLETTRAIN_PROMPT_SEPARATE_LINE == false ]]; then


### PR DESCRIPTION
1. Fixed root prompt issue: if you tap "git check" and then press tab to autocomplete in root mode the command line becomes red because is not correctly rested.

2. Added prompt color variable to solve [issue-144](https://github.com/caiogondim/bullet-train.zsh/issues/144)  (cc @dawikur )

3. Added the two new variables to #PROPMT docs.