### PR TITLE
Add space only if non-empty BULLETTRAIN_PROMPT_CHAR

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -600,7 +600,11 @@ prompt_chars() {
     bt_prompt_chars="${bt_prompt_chars}"
   fi
 
-  echo -n "$bt_prompt_chars "
+  echo -n "$bt_prompt_chars"
+
+  if [[ -n $BULLETTRAIN_PROMPT_CHAR ]]; then
+    echo -n " "
+  fi
 }
 
 # Prompt Line Separator


### PR DESCRIPTION
Add space after `BULLETTRAIN_PROMPT_CHAR` only if it's non empty. When it's empty, it looks better because there's no extra spaces at the end of the prompt.

![2017-12-20-202056_1280x761_scrot](https://user-images.githubusercontent.com/616169/34224618-b93956a6-e5c3-11e7-9b2b-4c1f3c614dac.png)
![2017-12-20-202129_1280x761_scrot](https://user-images.githubusercontent.com/616169/34224619-b95ad5ce-e5c3-11e7-96eb-4e0469ce2b84.png)
![2017-12-20-202159_1280x761_scrot](https://user-images.githubusercontent.com/616169/34224620-b97a0b92-e5c3-11e7-999e-2cc7bc5db86f.png)
![2017-12-20-202211_1280x761_scrot](https://user-images.githubusercontent.com/616169/34224621-b9961490-e5c3-11e7-9f22-e6b588c8aaed.png)
