### PR TITLE
Adds a Kubernetes Context Segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,17 @@ NOTE: You do not need to specify *end* segment - it will be added automatically.
 |`BULLETTRAIN_GO_FG`|`white`|Foreground color
 |`BULLETTRAIN_GO_PREFIX`|`go`|Prefix of the segment
 
+### Kubernetes Context
+
+|Variable|Default|Meaning
+|--------|-------|-------|
+|`BULLETTRAIN_KCTX_BG`|`yellow`|Background color
+|`BULLETTRAIN_KCTX_FG`|`white`|Foreground color
+|`BULLETTRAIN_KCTX_PREFIX`|`⎈`|[Kubernetes](https://unicode-table.com/de/2388/) prefix of the segment
+|`BULLETTRAIN_KCTX_KCONFIG`|`<MUST_BE_SET>`|Location of kube config file (e.g. /Users/Hugo/.kube/config)
+
+`BULLETTRAIN_KCTX_KCONFIG` must be set, e.g. in .zshrc. There can be no default value and `~/` can not be reliably interpreted. The prompt will also do a sanity check whether `kubectl` is installed. If either condition fails, the prompt segment will not be drawn at all. 
+
 ### AWS Profile
 
 Displays which AWS (Amazon Web Services) credentials profile is currently set.

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -139,6 +139,17 @@ if [ ! -n "${BULLETTRAIN_GO_PREFIX+1}" ]; then
   BULLETTRAIN_GO_PREFIX="go"
 fi
 
+# Kubernetes Context
+if [ ! -n "${BULLETTRAIN_KCTX_BG+1}" ]; then
+  BULLETTRAIN_KCTX_BG=yellow
+fi
+if [ ! -n "${BULLETTRAIN_KCTX_FG+1}" ]; then
+  BULLETTRAIN_KCTX_FG=white
+fi
+if [ ! -n "${BULLETTRAIN_KCTX_PREFIX+1}" ]; then
+  BULLETTRAIN_KCTX_PREFIX="⎈"
+fi
+
 # ELIXIR
 if [ ! -n "${BULLETTRAIN_ELIXIR_BG+1}" ]; then
   BULLETTRAIN_ELIXIR_BG=magenta
@@ -515,6 +526,18 @@ prompt_go() {
     if command -v go > /dev/null 2>&1; then
       prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
     fi
+  fi
+}
+
+# Kubernetes Context
+prompt_kctx() {
+  if [[ ! -n $BULLETTRAIN_KCTX_KCONFIG ]]; then
+    return
+  fi
+  if command -v kubectl > /dev/null 2>&1; then
+    if [[ -f $BULLETTRAIN_KCTX_KCONFIG ]]; then
+      prompt_segment $BULLETTRAIN_KCTX_BG $BULLETTRAIN_KCTX_FG $BULLETTRAIN_KCTX_PREFIX" $(cat $BULLETTRAIN_KCTX_KCONFIG|grep current-context| awk '{print $2}')"
+    fi  
   fi
 }
 


### PR DESCRIPTION
This PR adds a Kubernetes context segment.

It requires the user to at least set `BULLETTRAIN_KCTX_KCONFIG` to a valid kubeconfig location (e.g. `/Users/<username>/.kube/config` on OSX) and have `kubectl` installed.

Other variables supported (with default values):

```
BULLETTRAIN_KCTX_BG # Background color, default: yellow
BULLETTRAIN_KCTX_FG # Foreground color, default: white
BULLETTRAIN_KCTX_PREFIX # Segment prefix, default: ⎈
```

Example:
<img width="310" alt="bildschirmfoto 2017-12-25 um 00 01 16" src="https://user-images.githubusercontent.com/15986659/34329592-1378a202-e907-11e7-9bc2-11de302ccd7b.png">
