### PR TITLE
Fix issue #255: use awk to get golang version

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -536,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | awk '{print substr($3, 3)}')"
     fi
   fi
 }


### PR DESCRIPTION
Fixed #255 by using `awk` instead of `grep`.

There is 5 types of version format: `go1`, `go1.10beta1`, `go1.10`, `go1.8.5rc4`, `go1.9.2`.
So I think that getting 3rd word in `$ go version` command is better then using regex matching.


<img width="434" alt="2018-02-18 11 17 03" src="https://user-images.githubusercontent.com/35624130/36352816-873a05d4-14b6-11e8-9797-6644e82c32c6.png">
