### PR TITLE
Improve `prompt_go`

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -534,9 +534,9 @@ prompt_perl() {
 # Go
 prompt_go() {
   setopt extended_glob
-  if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
+  if [[ ($(echo *.go(#qN)) || -f Gopkg.toml || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]]+\.[[:digit:]]+\.*[[:digit:]]*')"
     fi
   fi
 }


### PR DESCRIPTION
1. Support `dep`. 
1. Show correct version of `go` like 1.10 and 1.9.2 etc.
1. Support multiple `go` files in the directory.