### PR TITLE
Updating regex for printing go version

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -536,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]]+\.([[:digit:]]+\.?)+')"
     fi
   fi
 }


### PR DESCRIPTION
Since i use go 1.10, i can see in my bar the version is go 1.1 that's not the true :)
I try multiple case and upgrade the regex for the go tooling.
you can try here : https://regex101.com/r/bWTMwf/1

Hope it will help ^^