### PR TITLE
fix bug in golang version argument

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -21,6 +21,7 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     time
     status
     custom
+    context
     dir
     screen
     perl
@@ -535,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version |cut -d ' ' -f3 | cut -c '3-')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | awk '{print substr($3,3)}')"
     fi
   fi
 }

--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -21,7 +21,6 @@ if [ ! -n "${BULLETTRAIN_PROMPT_ORDER+1}" ]; then
     time
     status
     custom
-    context
     dir
     screen
     perl
@@ -536,7 +535,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version |cut -d ' ' -f3 | cut -c '3-')"
     fi
   fi
 }


### PR DESCRIPTION
the current version is 1.10.1 which will cause the new line in the matching pattern as shown below. 

```bash
$ go version | grep -oE "[[:digit:]].[[:digit:]]"
1.1
0.1
```
to fix this issue, changing to pure cut command in the request.