### PR TITLE
Fix Go version prompt

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -536,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]]\.[[:digit:]]+')"
     fi
   fi
 }


### PR DESCRIPTION
Fixes Go version prompt for newer Go versions (especially dot releases). Only displays major and first minor version, e.g. 1.10 but not 1.10.1.

Before:
![image](https://user-images.githubusercontent.com/15986659/38615527-49b6ea98-3d91-11e8-81a2-327faa800c35.png)

After:
![image](https://user-images.githubusercontent.com/15986659/38615544-56130ff6-3d91-11e8-965a-b5487ecbc731.png)
