### PR TITLE
Changed Go Versioning output to allow multiple segments

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -536,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '(\d+\.)?(\d+\.)?(\*|\d+)' | head -1)"
     fi
   fi
 }


### PR DESCRIPTION
Hello there, 

Pardon if this is not the correct way to approach this. Yup this might be my first PR. Love the bullet-train theme. Today I started learning about go and noticed that there is an issue with multi segmented versions on the prompt output. It would look

1.1
0.10

and have a lot of white space. I think this new regex will work as long as the version number comes first. 

Let me know if you want to discuss it's just a suggestion and appears to work with at least the current go version information. 