### PR TITLE
Update go version matching

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -536,7 +536,7 @@ prompt_go() {
   setopt extended_glob
   if [[ (-f *.go(#qN) || -d Godeps || -f glide.yaml) ]]; then
     if command -v go > /dev/null 2>&1; then
-      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oE '[[:digit:]].[[:digit:]]')"
+      prompt_segment $BULLETTRAIN_GO_BG $BULLETTRAIN_GO_FG $BULLETTRAIN_GO_PREFIX" $(go version | grep --colour=never -oP '\d+\.[\d\.]+')"
     fi
   fi
 }


### PR DESCRIPTION
Update go version matching: `[[:digit:]].[[:digit:]]` doesn't match correctly for double digits
and/or full semantic versioning (e.g. `1.10` or `1.8.1`).