### PR TITLE
fix #296

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -552,6 +552,7 @@ prompt_rust() {
 
 # Kubernetes Context
 prompt_kctx() {
+  BULLETTRAIN_KCTX_KCONFIG=$(echo ${BULLETTRAIN_KCTX_KCONFIG} | cut -d":" -f1)
   if [[ ! -n $BULLETTRAIN_KCTX_KCONFIG ]]; then
     return
   fi


### PR DESCRIPTION
We can fix #296 issue with a small change in code because the kubectl `config` command use from first config file to read and write `current-context` value.