### PR TITLE
Remove display of nvm system alias

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -589,9 +589,7 @@ prompt_nvm() {
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
     nvm_prompt=$(nvm current 2>/dev/null)
-    [[ "${nvm_prompt}x" == "x" ]] && return
-  elif type node >/dev/null 2>&1; then
-    nvm_prompt="$(node --version)"
+    [[ "${nvm_prompt}x" == "x" || "${system}" == "system" ]] && return
   else
     return
   fi


### PR DESCRIPTION
Remove display of nvm system alias, as it uses system node version instead of nvm installed version.
Remove checking for node version when nvm is not installed as it makes no sense to display the system version without nvm.