### PR TITLE
hide Node version in prompt when `nvm` is installed and system node …

### DIFF
--- a/bullet-train.zsh-theme
+++ b/bullet-train.zsh-theme
@@ -589,7 +589,7 @@ prompt_nvm() {
   local nvm_prompt
   if type nvm >/dev/null 2>&1; then
     nvm_prompt=$(nvm current 2>/dev/null)
-    [[ "${nvm_prompt}x" == "x" ]] && return
+    [[ "${nvm_prompt}x" == "x" || "${nvm_prompt}" == "system" ]] && return
   elif type node >/dev/null 2>&1; then
     nvm_prompt="$(node --version)"
   else


### PR DESCRIPTION
hide Node version in prompt when `nvm` is installed and nvm is returning `system` alias. There is no need to display `system` in the prompt.